### PR TITLE
Fix inputs and outputs

### DIFF
--- a/src/core-decorators/utils/binding.js
+++ b/src/core-decorators/utils/binding.js
@@ -4,7 +4,7 @@ export let toBinding = (params, type) => {
         params.forEach((param) => {
             let id = param, value = '';
             if (param.includes(': ')) {
-                param.split(': ');
+                param = param.split(': ');
                 [id, value] = param;
             }
             bindings[id] = type + value;


### PR DESCRIPTION
Use the resulting array from split instead of the original string.
